### PR TITLE
Added dkms deb building into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ config_check:
 		echo; echo; \
 	fi
 
+# Taken from here:
+# http://www.xkyle.com/building-linux-packages-for-kernel-drivers/
 
 dkms:
 	$(MAKE) config_check


### PR DESCRIPTION
I thought that it could streamline testing changes for those that don't yet know how to build DKMS packages. This is a straightforward way of doing it, copied from [this tutorial](http://www.xkyle.com/building-linux-packages-for-kernel-drivers/), so some steps might not be strictly necessary.