### PR TITLE
Fix compile for kernel 4.14.30

### DIFF
--- a/esp_sip.c
+++ b/esp_sip.c
@@ -1612,10 +1612,18 @@ static int sip_parse_mac_rx_info(struct esp_sip *sip, struct esp_mac_rx_ctrl * m
         if (mac_ctrl->sig_mode) {
             // 2.6.27 has RX_FLAG_RADIOTAP in enum mac80211_rx_flags in include/net/mac80211.h
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29))                
+# if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0))
                 rx_status->flag |= RX_FLAG_HT;
+# else
+                rx_status->encoding = RX_ENC_HT;
+# endif
                 rx_status->rate_idx = mac_ctrl->MCS;
                 if(mac_ctrl->SGI)
+# if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0))
                         rx_status->flag |= RX_FLAG_SHORT_GI;
+# else
+                        rx_status->enc_flags |= RX_ENC_FLAG_SHORT_GI;
+# endif
 #else
                 rx_status->rate_idx = esp_wmac_rate2idx(0xc);//ESP_RATE_54
 #endif


### PR DESCRIPTION
Compilation of `esp_sip.c` fails on latest kernel 4.14.30 due to the cleanup of rate encoding bits in RX status. Ref. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/include/net/mac80211.h?h=v4.12&id=7fdd69c5af2160236e97668bc1fb7d70855c66ae et al.

This PR aligns the module with recent kernels while maintaining backward compatibility with older kernel versions (changes inspired by https://www.mail-archive.com/lede-dev@lists.infradead.org/msg08605.html).
